### PR TITLE
feat(purchases): implement bulk add purchases with transactional rpc

### DIFF
--- a/src/app/purchases/bulk-add/page.tsx
+++ b/src/app/purchases/bulk-add/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { DataService } from "@/lib/services/dataService";
+import { CreditCard, Person } from "@/lib/supabase";
+import BulkPurchaseForm from "@/components/purchases/BulkPurchaseForm";
+import { LoadingSpinner } from "@/components/base";
+
+export default function BulkAddPurchasesPage() {
+    const router = useRouter();
+    const [creditCards, setCreditCards] = useState<CreditCard[]>([]);
+    const [persons, setPersons] = useState<Person[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        async function loadMetadata() {
+            try {
+                setIsLoading(true);
+                setError(null);
+                const [creditCardsData, personsData] = await Promise.all([
+                    DataService.loadCreditCards(),
+                    DataService.loadPersons(),
+                ]);
+                setCreditCards(creditCardsData);
+                setPersons(personsData);
+            } catch (err) {
+                console.error("Failed to load metadata for bulk add:", err);
+                setError("Failed to load credit cards or persons. Please try again.");
+            } finally {
+                setIsLoading(false);
+            }
+        }
+        loadMetadata();
+    }, []);
+
+    const handleSubmit = async (purchases: Array<{
+        credit_card_id: string;
+        person_id: string;
+        purchase_date: string;
+        billing_start_date: string;
+        total_amount: number;
+        description: string;
+        num_installments: number;
+        is_bnpl: boolean;
+    }>) => {
+        try {
+            await DataService.bulkCreatePurchasesWithTransactions(purchases);
+            router.push("/purchases");
+            router.refresh();
+        } catch (error) {
+            console.error("Error submitting bulk purchases:", error);
+            throw error;
+        }
+    };
+
+    if (isLoading) {
+        return (
+            <div className="container mx-auto p-8 text-center">
+                <LoadingSpinner />
+                <p className="mt-2 text-gray-400">Loading forms and account details...</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="container mx-auto space-y-6">
+            <div className="mb-4">
+                <Link href="/purchases" className="btn btn-ghost btn-sm gap-2">
+                    <ArrowLeft className="w-4 h-4" />
+                    Back to Purchases
+                </Link>
+            </div>
+
+            <div className="flex flex-col md:flex-row md:items-center justify-between border-b border-gray-800 pb-4">
+                <div>
+                    <h1 className="heading-page">Bulk Add Purchases</h1>
+                    <p className="text-gray-400 text-sm mt-1">
+                        Add multiple purchases to the system in a single operation.
+                    </p>
+                </div>
+            </div>
+
+            {error ? (
+                <div className="alert alert-error">
+                    <span>{error}</span>
+                </div>
+            ) : (
+                <BulkPurchaseForm
+                    creditCards={creditCards}
+                    persons={persons}
+                    onSubmit={handleSubmit}
+                    onCancel={() => router.push("/purchases")}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/app/purchases/page.tsx
+++ b/src/app/purchases/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { Purchase, CreditCard, Person } from "@/lib/supabase";
 import DataTable from "@/components/DataTable";
 import Modal from "@/components/Modal";
@@ -10,7 +11,7 @@ import TransactionFilters, {
 import { DataService } from "@/lib/services/dataService";
 import { LoadingSpinner } from "@/components/base";
 import ActionButton from "@/components/base/ActionButton";
-import { Eye, Trash2 } from "lucide-react";
+import { Eye, Trash2, ListPlus } from "lucide-react";
 import { formatCurrency, formatDate } from "@/lib/utils";
 
 export default function PurchasesPage() {
@@ -131,9 +132,15 @@ export default function PurchasesPage() {
     return (
         <div className="container space-y-5 mx-auto">
             <h1 className="heading-page">Purchases</h1>
-            <button onClick={openAddModal} className="btn btn-primary">
-                Add Purchase
-            </button>
+            <div className="flex gap-3 items-center">
+                <button onClick={openAddModal} className="btn btn-primary">
+                    Add Purchase
+                </button>
+                <Link href="/purchases/bulk-add" className="btn btn-outline flex items-center gap-2">
+                    <ListPlus className="w-4 h-4" />
+                    Bulk Add Purchases
+                </Link>
+            </div>
 
             <TransactionFilters
                 config={{

--- a/src/components/purchases/BulkPurchaseForm.tsx
+++ b/src/components/purchases/BulkPurchaseForm.tsx
@@ -50,39 +50,43 @@ export default function BulkPurchaseForm({
     // Grid rows state
     const [rows, setRows] = useState<BulkRow[]>([]);
 
-    // Initialize defaults on component mount once metadata is loaded
+    // Initialize defaults and the initial empty row on component mount / metadata load
     useEffect(() => {
-        if (creditCards.length > 0 && !defaultCard) {
-            setDefaultCard(creditCards[0].id);
-        }
-        if (persons.length > 0 && !defaultPerson) {
-            setDefaultPerson(persons[0].id);
-        }
-        if (!defaultPurchaseDate) {
-            const today = new Date().toISOString().split("T")[0];
-            setDefaultPurchaseDate(today);
-            setDefaultBillingDate(today);
-        }
-    }, [creditCards, persons, defaultCard, defaultPerson, defaultPurchaseDate]);
+        const today = new Date().toISOString().split("T")[0];
+        const initialCard = creditCards.length > 0 ? creditCards[0].id : "";
+        const initialPerson = persons.length > 0 ? persons[0].id : "";
 
-    // Initialize with one empty row once defaults are ready
-    useEffect(() => {
-        if (defaultCard && defaultPerson && defaultPurchaseDate && rows.length === 0) {
-            setRows([
+        setDefaultCard((prev) => prev || initialCard);
+        setDefaultPerson((prev) => prev || initialPerson);
+        setDefaultPurchaseDate((prev) => prev || today);
+        setDefaultBillingDate((prev) => prev || today);
+
+        setRows((prev) => {
+            if (prev.length > 0) {
+                // Propagate loaded defaults to empty row values
+                return prev.map((row) => ({
+                    ...row,
+                    credit_card_id: row.credit_card_id || initialCard,
+                    person_id: row.person_id || initialPerson,
+                    purchase_date: row.purchase_date || today,
+                    billing_start_date: row.billing_start_date || today,
+                }));
+            }
+            return [
                 {
                     id: Math.random().toString(36).substring(2, 9),
                     description: "",
                     total_amount: "",
                     num_installments: "1",
-                    credit_card_id: defaultCard,
-                    person_id: defaultPerson,
-                    purchase_date: defaultPurchaseDate,
-                    billing_start_date: defaultBillingDate,
+                    credit_card_id: initialCard,
+                    person_id: initialPerson,
+                    purchase_date: today,
+                    billing_start_date: today,
                     is_bnpl: false,
                 },
-            ]);
-        }
-    }, [defaultCard, defaultPerson, defaultPurchaseDate, defaultBillingDate, rows.length]);
+            ];
+        });
+    }, [creditCards, persons]);
 
     const createNewRow = (overrides?: Partial<BulkRow>): BulkRow => {
         return {
@@ -208,6 +212,12 @@ export default function BulkPurchaseForm({
             const rowNum = index + 1;
             if (!row.description.trim()) {
                 errors.push(`Row ${rowNum}: Description is required`);
+            }
+            if (!row.credit_card_id) {
+                errors.push(`Row ${rowNum}: Credit Card is required`);
+            }
+            if (!row.person_id) {
+                errors.push(`Row ${rowNum}: Person is required`);
             }
             const amount = parseFloat(row.total_amount);
             if (isNaN(amount) || amount <= 0) {

--- a/src/components/purchases/BulkPurchaseForm.tsx
+++ b/src/components/purchases/BulkPurchaseForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Select, DateInput, Input, Checkbox, Button } from "@/components/base";
+import { Select, DateInput, Button } from "@/components/base";
 import { CreditCard, Person } from "@/lib/supabase";
 import { Trash2, Copy, Plus, RotateCcw } from "lucide-react";
 
@@ -68,9 +68,21 @@ export default function BulkPurchaseForm({
     // Initialize with one empty row once defaults are ready
     useEffect(() => {
         if (defaultCard && defaultPerson && defaultPurchaseDate && rows.length === 0) {
-            handleAddRow();
+            setRows([
+                {
+                    id: Math.random().toString(36).substring(2, 9),
+                    description: "",
+                    total_amount: "",
+                    num_installments: "1",
+                    credit_card_id: defaultCard,
+                    person_id: defaultPerson,
+                    purchase_date: defaultPurchaseDate,
+                    billing_start_date: defaultBillingDate,
+                    is_bnpl: false,
+                },
+            ]);
         }
-    }, [defaultCard, defaultPerson, defaultPurchaseDate]);
+    }, [defaultCard, defaultPerson, defaultPurchaseDate, defaultBillingDate, rows.length]);
 
     const createNewRow = (overrides?: Partial<BulkRow>): BulkRow => {
         return {
@@ -108,7 +120,7 @@ export default function BulkPurchaseForm({
         }
     };
 
-    const handleRowChange = (id: string, field: keyof BulkRow, value: any) => {
+    const handleRowChange = (id: string, field: keyof BulkRow, value: string | number | boolean) => {
         setRows((prev) =>
             prev.map((row) => {
                 if (row.id === id) {
@@ -116,7 +128,7 @@ export default function BulkPurchaseForm({
                     
                     // If purchase date changes, we might want billing date to follow it by default (if not manually set differently)
                     if (field === "purchase_date" && row.billing_start_date === row.purchase_date) {
-                        updated.billing_start_date = value;
+                        updated.billing_start_date = value as string;
                     }
                     
                     return updated;

--- a/src/components/purchases/BulkPurchaseForm.tsx
+++ b/src/components/purchases/BulkPurchaseForm.tsx
@@ -52,7 +52,8 @@ export default function BulkPurchaseForm({
 
     // Initialize defaults and the initial empty row on component mount / metadata load
     useEffect(() => {
-        const today = new Date().toISOString().split("T")[0];
+        // Use local timezone date so UTC offset doesn't shift displayed date
+        const today = new Date().toLocaleDateString("sv-SE"); // "sv-SE" locale = YYYY-MM-DD
         const initialCard = creditCards.length > 0 ? creditCards[0].id : "";
         const initialPerson = persons.length > 0 ? persons[0].id : "";
 

--- a/src/components/purchases/BulkPurchaseForm.tsx
+++ b/src/components/purchases/BulkPurchaseForm.tsx
@@ -1,0 +1,525 @@
+import React, { useState, useEffect } from "react";
+import { Select, DateInput, Input, Checkbox, Button } from "@/components/base";
+import { CreditCard, Person } from "@/lib/supabase";
+import { Trash2, Copy, Plus, RotateCcw } from "lucide-react";
+
+interface BulkRow {
+    id: string;
+    description: string;
+    total_amount: string;
+    num_installments: string;
+    credit_card_id: string;
+    person_id: string;
+    purchase_date: string;
+    billing_start_date: string;
+    is_bnpl: boolean;
+}
+
+interface BulkPurchaseFormProps {
+    creditCards: CreditCard[];
+    persons: Person[];
+    onSubmit: (purchases: Array<{
+        credit_card_id: string;
+        person_id: string;
+        purchase_date: string;
+        billing_start_date: string;
+        total_amount: number;
+        description: string;
+        num_installments: number;
+        is_bnpl: boolean;
+    }>) => Promise<void>;
+    onCancel: () => void;
+}
+
+export default function BulkPurchaseForm({
+    creditCards,
+    persons,
+    onSubmit,
+    onCancel,
+}: BulkPurchaseFormProps) {
+    // Top-level defaults
+    const [defaultCard, setDefaultCard] = useState("");
+    const [defaultPerson, setDefaultPerson] = useState("");
+    const [defaultPurchaseDate, setDefaultPurchaseDate] = useState("");
+    const [defaultBillingDate, setDefaultBillingDate] = useState("");
+
+    // Form submission/loading state
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
+    // Grid rows state
+    const [rows, setRows] = useState<BulkRow[]>([]);
+
+    // Initialize defaults on component mount once metadata is loaded
+    useEffect(() => {
+        if (creditCards.length > 0 && !defaultCard) {
+            setDefaultCard(creditCards[0].id);
+        }
+        if (persons.length > 0 && !defaultPerson) {
+            setDefaultPerson(persons[0].id);
+        }
+        if (!defaultPurchaseDate) {
+            const today = new Date().toISOString().split("T")[0];
+            setDefaultPurchaseDate(today);
+            setDefaultBillingDate(today);
+        }
+    }, [creditCards, persons, defaultCard, defaultPerson, defaultPurchaseDate]);
+
+    // Initialize with one empty row once defaults are ready
+    useEffect(() => {
+        if (defaultCard && defaultPerson && defaultPurchaseDate && rows.length === 0) {
+            handleAddRow();
+        }
+    }, [defaultCard, defaultPerson, defaultPurchaseDate]);
+
+    const createNewRow = (overrides?: Partial<BulkRow>): BulkRow => {
+        return {
+            id: Math.random().toString(36).substring(2, 9),
+            description: "",
+            total_amount: "",
+            num_installments: "1",
+            credit_card_id: overrides?.credit_card_id || defaultCard,
+            person_id: overrides?.person_id || defaultPerson,
+            purchase_date: overrides?.purchase_date || defaultPurchaseDate,
+            billing_start_date: overrides?.billing_start_date || defaultBillingDate,
+            is_bnpl: overrides?.is_bnpl ?? false,
+            ...overrides,
+        };
+    };
+
+    const handleAddRow = () => {
+        setRows((prev) => [...prev, createNewRow()]);
+    };
+
+    const handleDuplicateRow = (row: BulkRow) => {
+        const duplicated = createNewRow({
+            ...row,
+            id: Math.random().toString(36).substring(2, 9), // ensure new ID
+        });
+        setRows((prev) => [...prev, duplicated]);
+    };
+
+    const handleRemoveRow = (id: string) => {
+        if (rows.length === 1) {
+            // Keep at least one row, just reset it
+            setRows([createNewRow()]);
+        } else {
+            setRows((prev) => prev.filter((r) => r.id !== id));
+        }
+    };
+
+    const handleRowChange = (id: string, field: keyof BulkRow, value: any) => {
+        setRows((prev) =>
+            prev.map((row) => {
+                if (row.id === id) {
+                    const updated = { ...row, [field]: value };
+                    
+                    // If purchase date changes, we might want billing date to follow it by default (if not manually set differently)
+                    if (field === "purchase_date" && row.billing_start_date === row.purchase_date) {
+                        updated.billing_start_date = value;
+                    }
+                    
+                    return updated;
+                }
+                return row;
+            })
+        );
+    };
+
+    // Update all rows to match top-level defaults if they match previous defaults
+    const handleDefaultCardChange = (cardId: string) => {
+        const prevDefault = defaultCard;
+        setDefaultCard(cardId);
+        setRows((prev) =>
+            prev.map((row) =>
+                row.credit_card_id === prevDefault ? { ...row, credit_card_id: cardId } : row
+            )
+        );
+    };
+
+    const handleDefaultPersonChange = (personId: string) => {
+        const prevDefault = defaultPerson;
+        setDefaultPerson(personId);
+        setRows((prev) =>
+            prev.map((row) =>
+                row.person_id === prevDefault ? { ...row, person_id: personId } : row
+            )
+        );
+    };
+
+    const handleDefaultPurchaseDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const date = e.target.value;
+        const prevDefault = defaultPurchaseDate;
+        setDefaultPurchaseDate(date);
+        
+        // Also sync default billing date if it was matching purchase date
+        const shouldSyncBilling = defaultBillingDate === prevDefault;
+        if (shouldSyncBilling) {
+            setDefaultBillingDate(date);
+        }
+
+        setRows((prev) =>
+            prev.map((row) => {
+                const updated = { ...row };
+                if (row.purchase_date === prevDefault) {
+                    updated.purchase_date = date;
+                }
+                if (shouldSyncBilling && row.billing_start_date === prevDefault) {
+                    updated.billing_start_date = date;
+                }
+                return updated;
+            })
+        );
+    };
+
+    const handleDefaultBillingDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const date = e.target.value;
+        const prevDefault = defaultBillingDate;
+        setDefaultBillingDate(date);
+        setRows((prev) =>
+            prev.map((row) =>
+                row.billing_start_date === prevDefault ? { ...row, billing_start_date: date } : row
+            )
+        );
+    };
+
+    const handleReset = () => {
+        if (window.confirm("Are you sure you want to clear all rows?")) {
+            setRows([createNewRow()]);
+            setValidationErrors([]);
+        }
+    };
+
+    const validateForm = (): boolean => {
+        const errors: string[] = [];
+        rows.forEach((row, index) => {
+            const rowNum = index + 1;
+            if (!row.description.trim()) {
+                errors.push(`Row ${rowNum}: Description is required`);
+            }
+            const amount = parseFloat(row.total_amount);
+            if (isNaN(amount) || amount <= 0) {
+                errors.push(`Row ${rowNum}: Total Amount must be a positive number`);
+            }
+            const installments = parseInt(row.num_installments, 10);
+            if (isNaN(installments) || installments < 1) {
+                errors.push(`Row ${rowNum}: Installments must be at least 1`);
+            }
+            if (!row.purchase_date) {
+                errors.push(`Row ${rowNum}: Purchase Date is required`);
+            }
+            if (!row.billing_start_date) {
+                errors.push(`Row ${rowNum}: Billing Start Date is required`);
+            }
+        });
+        setValidationErrors(errors);
+        return errors.length === 0;
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (isSubmitting) return;
+
+        if (!validateForm()) return;
+
+        setIsSubmitting(true);
+        try {
+            const formattedData = rows.map((row) => ({
+                credit_card_id: row.credit_card_id,
+                person_id: row.person_id,
+                purchase_date: row.purchase_date,
+                billing_start_date: row.billing_start_date,
+                total_amount: parseFloat(row.total_amount),
+                description: row.description.trim(),
+                num_installments: parseInt(row.num_installments, 10),
+                is_bnpl: row.is_bnpl,
+            }));
+            await onSubmit(formattedData);
+        } catch (error) {
+            console.error("Failed to submit bulk purchases:", error);
+            setValidationErrors([
+                error instanceof Error ? error.message : "An unexpected database error occurred.",
+            ]);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const formatCreditCardLabel = (card: CreditCard): string => {
+        return `${card.credit_card_name || card.issuer} **** ${
+            card.last_four_digits
+        }${card.is_supplementary ? " (Supplementary)" : ""}`;
+    };
+
+    const creditCardOptions = creditCards.map((card) => ({
+        value: card.id,
+        label: formatCreditCardLabel(card),
+    }));
+
+    const personOptions = persons.map((person) => ({
+        value: person.id,
+        label: person.name,
+    }));
+
+    return (
+        <form onSubmit={handleSubmit} data-component="BulkPurchaseForm" className="space-y-6" noValidate>
+            {/* Batch Defaults Card */}
+            <div className="card bg-gray-900 border border-gray-800 shadow-xl p-4 rounded-xl">
+                <h2 className="text-lg font-semibold mb-3 text-primary flex items-center gap-2">
+                    Batch Defaults
+                    <span className="text-xs font-normal text-gray-400">
+                        (Sets default values for new rows and cascades to unchanged existing rows)
+                    </span>
+                </h2>
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                    <div className="form-control">
+                        <span className="label-text mb-1">Default Credit Card</span>
+                        <Select
+                            name="default_card"
+                            value={defaultCard}
+                            onChange={handleDefaultCardChange}
+                            options={creditCardOptions}
+                            disabled={isSubmitting}
+                        />
+                    </div>
+                    <div className="form-control">
+                        <span className="label-text mb-1">Default Person</span>
+                        <Select
+                            name="default_person"
+                            value={defaultPerson}
+                            onChange={handleDefaultPersonChange}
+                            options={personOptions}
+                            disabled={isSubmitting}
+                        />
+                    </div>
+                    <div className="form-control">
+                        <span className="label-text mb-1">Default Purchase Date</span>
+                        <DateInput
+                            name="default_purchase_date"
+                            value={defaultPurchaseDate}
+                            onChange={handleDefaultPurchaseDateChange}
+                            disabled={isSubmitting}
+                        />
+                    </div>
+                    <div className="form-control">
+                        <span className="label-text mb-1">Default Billing Start Date</span>
+                        <DateInput
+                            name="default_billing_date"
+                            value={defaultBillingDate}
+                            onChange={handleDefaultBillingDateChange}
+                            disabled={isSubmitting}
+                        />
+                    </div>
+                </div>
+            </div>
+
+            {/* Error alerts */}
+            {validationErrors.length > 0 && (
+                <div className="alert alert-error bg-red-950 border border-red-800 text-red-200 p-4 rounded-xl space-y-1">
+                    <div className="font-semibold text-sm">Please correct the following errors:</div>
+                    <ul className="list-disc pl-5 text-xs space-y-0.5">
+                        {validationErrors.slice(0, 5).map((err, i) => (
+                            <li key={i}>{err}</li>
+                        ))}
+                        {validationErrors.length > 5 && (
+                            <li>...and {validationErrors.length - 5} more errors.</li>
+                        )}
+                    </ul>
+                </div>
+            )}
+
+            {/* Multi-Row Spreadsheet Table */}
+            <div className="overflow-x-auto border border-gray-800 rounded-xl bg-gray-950 shadow-inner">
+                <table className="table table-compact w-full text-left border-collapse min-w-[1200px]">
+                    <thead>
+                        <tr className="bg-gray-900 border-b border-gray-800 text-gray-400 text-xs uppercase">
+                            <th className="p-3 w-8">#</th>
+                            <th className="p-3 w-1/4">Description</th>
+                            <th className="p-3 w-32">Total Amount</th>
+                            <th className="p-3 w-24">Installments</th>
+                            <th className="p-3 w-48">Credit Card</th>
+                            <th className="p-3 w-40">Person</th>
+                            <th className="p-3 w-40">Purchase Date</th>
+                            <th className="p-3 w-40">Billing Start Date</th>
+                            <th className="p-3 w-20 text-center">BNPL</th>
+                            <th className="p-3 w-24 text-center">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-800">
+                        {rows.map((row, index) => {
+                            const hasLocalDescError = validationErrors.some(e => e.includes(`Row ${index + 1}: Description`));
+                            const hasLocalAmountError = validationErrors.some(e => e.includes(`Row ${index + 1}: Total Amount`));
+                            const hasLocalInstError = validationErrors.some(e => e.includes(`Row ${index + 1}: Installments`));
+                            
+                            return (
+                                <tr key={row.id} className="hover:bg-gray-900/50 transition-colors">
+                                    <td className="p-3 text-center text-sm font-medium text-gray-500">
+                                        {index + 1}
+                                    </td>
+                                    {/* Description */}
+                                    <td className="p-2">
+                                        <input
+                                            type="text"
+                                            className={`input input-bordered input-sm w-full bg-gray-900 border-gray-800 focus:border-primary focus:ring-1 focus:ring-primary ${
+                                                hasLocalDescError ? "border-red-600 focus:border-red-600 focus:ring-red-600" : ""
+                                            }`}
+                                            placeholder="MacBook Pro, Groceries, etc."
+                                            value={row.description}
+                                            onChange={(e) => handleRowChange(row.id, "description", e.target.value)}
+                                            required
+                                            disabled={isSubmitting}
+                                        />
+                                    </td>
+                                    {/* Total Amount */}
+                                    <td className="p-2">
+                                        <input
+                                            type="number"
+                                            step="0.01"
+                                            min="0.01"
+                                            className={`input input-bordered input-sm w-full bg-gray-900 border-gray-800 focus:border-primary focus:ring-1 focus:ring-primary ${
+                                                hasLocalAmountError ? "border-red-600 focus:border-red-600 focus:ring-red-600" : ""
+                                            }`}
+                                            placeholder="0.00"
+                                            value={row.total_amount}
+                                            onChange={(e) => handleRowChange(row.id, "total_amount", e.target.value)}
+                                            required
+                                            disabled={isSubmitting}
+                                        />
+                                    </td>
+                                    {/* Installments */}
+                                    <td className="p-2">
+                                        <input
+                                            type="number"
+                                            min="1"
+                                            className={`input input-bordered input-sm w-full bg-gray-900 border-gray-800 focus:border-primary focus:ring-1 focus:ring-primary ${
+                                                hasLocalInstError ? "border-red-600 focus:border-red-600 focus:ring-red-600" : ""
+                                            }`}
+                                            value={row.num_installments}
+                                            onChange={(e) => handleRowChange(row.id, "num_installments", e.target.value)}
+                                            required
+                                            disabled={isSubmitting}
+                                        />
+                                    </td>
+                                    {/* Credit Card */}
+                                    <td className="p-2">
+                                        <Select
+                                            name={`card-${row.id}`}
+                                            value={row.credit_card_id}
+                                            onChange={(val) => handleRowChange(row.id, "credit_card_id", val)}
+                                            options={creditCardOptions}
+                                            disabled={isSubmitting}
+                                        />
+                                    </td>
+                                    {/* Person */}
+                                    <td className="p-2">
+                                        <Select
+                                            name={`person-${row.id}`}
+                                            value={row.person_id}
+                                            onChange={(val) => handleRowChange(row.id, "person_id", val)}
+                                            options={personOptions}
+                                            disabled={isSubmitting}
+                                        />
+                                    </td>
+                                    {/* Purchase Date */}
+                                    <td className="p-2">
+                                        <DateInput
+                                            name={`purchase-date-${row.id}`}
+                                            value={row.purchase_date}
+                                            onChange={(e) => handleRowChange(row.id, "purchase_date", e.target.value)}
+                                            disabled={isSubmitting}
+                                        />
+                                    </td>
+                                    {/* Billing Start Date */}
+                                    <td className="p-2">
+                                        <DateInput
+                                            name={`billing-date-${row.id}`}
+                                            value={row.billing_start_date}
+                                            onChange={(e) => handleRowChange(row.id, "billing_start_date", e.target.value)}
+                                            disabled={isSubmitting}
+                                        />
+                                    </td>
+                                    {/* BNPL */}
+                                    <td className="p-2 text-center">
+                                        <input
+                                            type="checkbox"
+                                            className="checkbox checkbox-primary checkbox-sm bg-gray-900 border-gray-800"
+                                            checked={row.is_bnpl}
+                                            onChange={(e) => handleRowChange(row.id, "is_bnpl", e.target.checked)}
+                                            disabled={isSubmitting}
+                                        />
+                                    </td>
+                                    {/* Action buttons */}
+                                    <td className="p-2 text-center">
+                                        <div className="flex items-center justify-center gap-1">
+                                            <button
+                                                type="button"
+                                                title="Duplicate Row"
+                                                onClick={() => handleDuplicateRow(row)}
+                                                className="btn btn-ghost btn-xs text-info hover:bg-info/10 p-1"
+                                                disabled={isSubmitting}
+                                            >
+                                                <Copy className="w-3.5 h-3.5" />
+                                            </button>
+                                            <button
+                                                type="button"
+                                                title="Remove Row"
+                                                onClick={() => handleRemoveRow(row.id)}
+                                                className="btn btn-ghost btn-xs text-error hover:bg-error/10 p-1"
+                                                disabled={isSubmitting}
+                                            >
+                                                <Trash2 className="w-3.5 h-3.5" />
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+
+            {/* Bottom Actions */}
+            <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
+                <div className="flex gap-2">
+                    <Button
+                        type="button"
+                        onClick={handleAddRow}
+                        color="secondary"
+                        disabled={isSubmitting}
+                        className="flex items-center gap-2 btn-sm"
+                    >
+                        <Plus className="w-4 h-4" /> Add Row
+                    </Button>
+                    <Button
+                        type="button"
+                        onClick={handleReset}
+                        color="secondary"
+                        disabled={isSubmitting}
+                        className="flex items-center gap-2 btn-sm text-yellow-500 hover:bg-yellow-500/10"
+                    >
+                        <RotateCcw className="w-4 h-4" /> Clear All
+                    </Button>
+                </div>
+
+                <div className="flex gap-2 w-full sm:w-auto justify-end">
+                    <Button
+                        type="button"
+                        onClick={onCancel}
+                        color="secondary"
+                        disabled={isSubmitting}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        type="submit"
+                        color="primary"
+                        disabled={isSubmitting}
+                        className="min-w-[120px]"
+                    >
+                        {isSubmitting ? "Saving Bulk..." : `Save ${rows.length} Purchase${rows.length > 1 ? "s" : ""}`}
+                    </Button>
+                </div>
+            </div>
+        </form>
+    );
+}

--- a/src/components/purchases/__tests__/BulkPurchaseForm.test.tsx
+++ b/src/components/purchases/__tests__/BulkPurchaseForm.test.tsx
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import BulkPurchaseForm from "../BulkPurchaseForm";
+import { CreditCard, Person } from "@/lib/supabase";
+
+// Mock base components
+vi.mock("@/components/base", () => ({
+    Select: ({
+        name,
+        value,
+        onChange,
+        options,
+        disabled,
+    }: {
+        name: string;
+        value: string;
+        onChange: (value: string) => void;
+        options: { value: string; label: string }[];
+        disabled?: boolean;
+    }) => (
+        <select
+            data-testid={`select-${name}`}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={disabled}
+        >
+            {options?.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                </option>
+            ))}
+        </select>
+    ),
+    DateInput: ({
+        name,
+        value,
+        onChange,
+        disabled,
+    }: {
+        name: string;
+        value: string;
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+        disabled?: boolean;
+    }) => (
+        <input
+            data-testid={`date-${name}`}
+            type="date"
+            name={name}
+            value={value}
+            onChange={onChange}
+            disabled={disabled}
+        />
+    ),
+    Input: ({
+        label,
+        name,
+        type,
+        value,
+        onChange,
+        disabled,
+    }: {
+        label: string;
+        name: string;
+        type?: string;
+        value: string | number;
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+        disabled?: boolean;
+    }) => (
+        <div>
+            <label>{label}</label>
+            <input
+                data-testid={`input-${name}`}
+                type={type}
+                name={name}
+                value={value}
+                onChange={onChange}
+                disabled={disabled}
+            />
+        </div>
+    ),
+    Checkbox: ({
+        label,
+        name,
+        checked,
+        onChange,
+        disabled,
+    }: {
+        label: string;
+        name: string;
+        checked: boolean;
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+        disabled?: boolean;
+    }) => (
+        <div>
+            <label>
+                <input
+                    data-testid={`checkbox-${name}`}
+                    type="checkbox"
+                    name={name}
+                    checked={checked}
+                    onChange={onChange}
+                    disabled={disabled}
+                />
+                {label}
+            </label>
+        </div>
+    ),
+    Button: ({
+        type,
+        onClick,
+        disabled,
+        children,
+    }: {
+        type?: "button" | "submit" | "reset";
+        onClick?: () => void;
+        disabled?: boolean;
+        children: React.ReactNode;
+    }) => (
+        <button type={type} onClick={onClick} disabled={disabled}>
+            {children}
+        </button>
+    ),
+}));
+
+const mockCreditCards: CreditCard[] = [
+    {
+        id: "card-1",
+        credit_card_name: "Test Card 1",
+        last_four_digits: "1234",
+        cardholder_name: "John Doe",
+        issuer: "Visa",
+        is_supplementary: false,
+    },
+    {
+        id: "card-2",
+        credit_card_name: "Test Card 2",
+        last_four_digits: "5678",
+        cardholder_name: "Jane Doe",
+        issuer: "Mastercard",
+        is_supplementary: false,
+    },
+];
+
+const mockPersons: Person[] = [
+    { id: "person-1", name: "John Doe", slug: "john-doe" },
+    { id: "person-2", name: "Jane Doe", slug: "jane-doe" },
+];
+
+describe("BulkPurchaseForm", () => {
+    const mockOnSubmit = vi.fn();
+    const mockOnCancel = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const renderForm = () => {
+        return render(
+            <BulkPurchaseForm
+                creditCards={mockCreditCards}
+                persons={mockPersons}
+                onSubmit={mockOnSubmit}
+                onCancel={mockOnCancel}
+            />
+        );
+    };
+
+    it("should render default inputs and initial single empty row using defaults", async () => {
+        renderForm();
+
+        // Defaults card values
+        expect(screen.getByTestId("select-default_card")).toHaveValue("card-1");
+        expect(screen.getByTestId("select-default_person")).toHaveValue("person-1");
+
+        // Table elements
+        expect(screen.getByPlaceholderText("MacBook Pro, Groceries, etc.")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("0.00")).toBeInTheDocument();
+    });
+
+    it("should allow adding a new row", async () => {
+        const user = userEvent.setup();
+        renderForm();
+
+        const addButton = screen.getByText("Add Row");
+        await user.click(addButton);
+
+        // Now we should have 2 rows
+        const descriptions = screen.getAllByPlaceholderText("MacBook Pro, Groceries, etc.");
+        expect(descriptions).toHaveLength(2);
+    });
+
+    it("should allow removing a row", async () => {
+        const user = userEvent.setup();
+        renderForm();
+
+        // Add a row first
+        await user.click(screen.getByText("Add Row"));
+        expect(screen.getAllByPlaceholderText("MacBook Pro, Groceries, etc.")).toHaveLength(2);
+
+        // Click delete on the first row (the layout renders duplicate and trash icons)
+        // Wait, since we are using inline icons, let's find the trash button by Title or selector.
+        // We added title="Remove Row" in the code. Let's find by title.
+        const removeButtons = screen.getAllByTitle("Remove Row");
+        await user.click(removeButtons[0]);
+
+        expect(screen.getAllByPlaceholderText("MacBook Pro, Groceries, etc.")).toHaveLength(1);
+    });
+
+    it("should allow duplicating a row", async () => {
+        const user = userEvent.setup();
+        renderForm();
+
+        // Type description on the first row
+        const descInput = screen.getByPlaceholderText("MacBook Pro, Groceries, etc.");
+        await user.type(descInput, "Special Item");
+
+        // Duplicate the row
+        const duplicateButtons = screen.getAllByTitle("Duplicate Row");
+        await user.click(duplicateButtons[0]);
+
+        // Should have 2 rows, both with description "Special Item"
+        const descInputs = screen.getAllByPlaceholderText("MacBook Pro, Groceries, etc.");
+        expect(descInputs).toHaveLength(2);
+        expect(descInputs[0]).toHaveValue("Special Item");
+        expect(descInputs[1]).toHaveValue("Special Item");
+    });
+
+    it("should cascade top-level default changes to rows matching previous defaults", async () => {
+        const user = userEvent.setup();
+        renderForm();
+
+        // Change default person
+        await user.selectOptions(screen.getByTestId("select-default_person"), "person-2");
+
+        // Verify the row person is updated to person-2 since it matched the default
+        const personSelects = screen.getAllByTestId(/^select-person-/);
+        expect(personSelects[0]).toHaveValue("person-2");
+    });
+
+    it("should trigger validation errors on invalid inputs", async () => {
+        const user = userEvent.setup();
+        renderForm();
+
+        // Submit without typing anything (description is empty, amount is empty)
+        await user.click(screen.getByText("Save 1 Purchase"));
+
+        expect(screen.getByText("Please correct the following errors:")).toBeInTheDocument();
+        expect(screen.getByText("Row 1: Description is required")).toBeInTheDocument();
+        expect(screen.getByText("Row 1: Total Amount must be a positive number")).toBeInTheDocument();
+    });
+
+    it("should call onSubmit when validation succeeds", async () => {
+        const user = userEvent.setup();
+        renderForm();
+
+        // Type description
+        const descInput = screen.getByPlaceholderText("MacBook Pro, Groceries, etc.");
+        await user.type(descInput, "Bulk purchase 1");
+
+        // Type amount
+        const amountInput = screen.getByPlaceholderText("0.00");
+        await user.type(amountInput, "1500.50");
+
+        // Submit
+        mockOnSubmit.mockResolvedValue(undefined);
+        await user.click(screen.getByText("Save 1 Purchase"));
+
+        await waitFor(() => {
+            expect(mockOnSubmit).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    description: "Bulk purchase 1",
+                    total_amount: 1500.50,
+                    num_installments: 1,
+                    credit_card_id: "card-1",
+                    person_id: "person-1",
+                }),
+            ]);
+        });
+    });
+
+    it("should call onCancel when cancel is clicked", async () => {
+        const user = userEvent.setup();
+        renderForm();
+
+        await user.click(screen.getByText("Cancel"));
+
+        expect(mockOnCancel).toHaveBeenCalled();
+    });
+});

--- a/src/components/purchases/__tests__/BulkPurchaseForm.test.tsx
+++ b/src/components/purchases/__tests__/BulkPurchaseForm.test.tsx
@@ -287,4 +287,22 @@ describe("BulkPurchaseForm", () => {
 
         expect(mockOnCancel).toHaveBeenCalled();
     });
+
+    it("should validate missing credit card and person ids", async () => {
+        const user = userEvent.setup();
+        render(
+            <BulkPurchaseForm
+                creditCards={[]}
+                persons={[]}
+                onSubmit={mockOnSubmit}
+                onCancel={mockOnCancel}
+            />
+        );
+
+        await user.click(screen.getByText("Save 1 Purchase"));
+
+        expect(screen.getByText("Please correct the following errors:")).toBeInTheDocument();
+        expect(screen.getByText("Row 1: Credit Card is required")).toBeInTheDocument();
+        expect(screen.getByText("Row 1: Person is required")).toBeInTheDocument();
+    });
 });

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -213,5 +213,12 @@ describe("utils", () => {
             expect(addMonthsPreservingMonthEnd("2024-11-15", 2)).toBe("2025-01-15");
             expect(addMonthsPreservingMonthEnd("2024-12-31", 1)).toBe("2025-01-31");
         });
+
+        it("should handle leap-year edge case", () => {
+            // Feb 29 + 12 months = Feb 28 next year (non-leap)
+            expect(addMonthsPreservingMonthEnd("2024-02-29", 12)).toBe("2025-02-28");
+            // Feb 29 + 48 months = Feb 29 (leap year again)
+            expect(addMonthsPreservingMonthEnd("2024-02-29", 48)).toBe("2028-02-29");
+        });
     });
 });

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { cn, formatDate, formatCurrency, handleTransactionPaidChange } from "../utils";
+import { cn, formatDate, formatCurrency, handleTransactionPaidChange, addMonthsPreservingMonthEnd } from "../utils";
 import { supabase } from "../supabase";
 
 // Mock the supabase client
@@ -194,6 +194,24 @@ describe("utils", () => {
 
             expect(result[0]).toEqual({ id: "tx-1", paid: false });
             expect(result[1]).toEqual({ id: "tx-2", paid: true });
+        });
+    });
+
+    describe("addMonthsPreservingMonthEnd", () => {
+        it("should keep the same day for normal additions", () => {
+            expect(addMonthsPreservingMonthEnd("2024-01-15", 1)).toBe("2024-02-15");
+            expect(addMonthsPreservingMonthEnd("2024-01-15", 2)).toBe("2024-03-15");
+        });
+
+        it("should clamp month end overflow correctly (Postgres semantics)", () => {
+            expect(addMonthsPreservingMonthEnd("2024-01-31", 1)).toBe("2024-02-29"); // leap year
+            expect(addMonthsPreservingMonthEnd("2023-01-31", 1)).toBe("2023-02-28"); // non-leap year
+            expect(addMonthsPreservingMonthEnd("2024-08-31", 1)).toBe("2024-09-30"); // August 31 + 1 month
+        });
+
+        it("should roll over year boundaries correctly", () => {
+            expect(addMonthsPreservingMonthEnd("2024-11-15", 2)).toBe("2025-01-15");
+            expect(addMonthsPreservingMonthEnd("2024-12-31", 1)).toBe("2025-01-31");
         });
     });
 });

--- a/src/lib/services/__tests__/dataService.test.ts
+++ b/src/lib/services/__tests__/dataService.test.ts
@@ -6,6 +6,7 @@ import { supabase } from "@/lib/supabase";
 vi.mock("@/lib/supabase", () => ({
     supabase: {
         from: vi.fn(),
+        rpc: vi.fn(),
     },
 }));
 
@@ -359,6 +360,53 @@ describe("DataService", () => {
             await expect(
                 DataService.createPurchaseWithTransactions(purchaseData),
             ).rejects.toThrow("Transaction insert failed");
+        });
+    });
+
+    describe("bulkCreatePurchasesWithTransactions", () => {
+        const purchases = [
+            {
+                credit_card_id: "card-1",
+                person_id: "person-1",
+                purchase_date: "2024-01-15",
+                billing_start_date: "2024-02-01",
+                total_amount: 3000,
+                description: "Test Purchase 1",
+                num_installments: 3,
+                is_bnpl: false,
+            },
+            {
+                credit_card_id: "card-2",
+                person_id: "person-2",
+                purchase_date: "2024-01-16",
+                billing_start_date: "2024-02-02",
+                total_amount: 1000,
+                description: "Test Purchase 2",
+                num_installments: 1,
+                is_bnpl: true,
+            },
+        ];
+
+        it("should call RPC with correct parameters", async () => {
+            (supabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ error: null });
+
+            await DataService.bulkCreatePurchasesWithTransactions(purchases);
+
+            expect(supabase.rpc).toHaveBeenCalledWith(
+                "bulk_create_purchases_with_transactions",
+                {
+                    p_purchases: purchases,
+                },
+            );
+        });
+
+        it("should throw error if RPC fails", async () => {
+            const mockError = new Error("RPC call failed");
+            (supabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ error: mockError });
+
+            await expect(
+                DataService.bulkCreatePurchasesWithTransactions(purchases),
+            ).rejects.toThrow("RPC call failed");
         });
     });
 });

--- a/src/lib/services/__tests__/dataService.test.ts
+++ b/src/lib/services/__tests__/dataService.test.ts
@@ -387,10 +387,11 @@ describe("DataService", () => {
             },
         ];
 
-        it("should call RPC with correct parameters", async () => {
-            (supabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ error: null });
+        it("should call RPC with correct parameters and return created IDs", async () => {
+            const mockIds = ["purchase-id-1", "purchase-id-2"];
+            (supabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockIds, error: null });
 
-            await DataService.bulkCreatePurchasesWithTransactions(purchases);
+            const result = await DataService.bulkCreatePurchasesWithTransactions(purchases);
 
             expect(supabase.rpc).toHaveBeenCalledWith(
                 "bulk_create_purchases_with_transactions",
@@ -398,6 +399,7 @@ describe("DataService", () => {
                     p_purchases: purchases,
                 },
             );
+            expect(result).toEqual(mockIds);
         });
 
         it("should throw error if RPC fails", async () => {

--- a/src/lib/services/dataService.ts
+++ b/src/lib/services/dataService.ts
@@ -161,4 +161,31 @@ export class DataService {
             throw error;
         }
     }
+
+    static async bulkCreatePurchasesWithTransactions(
+        purchases: Array<{
+            credit_card_id: string;
+            person_id: string;
+            purchase_date: string;
+            billing_start_date: string;
+            total_amount: number;
+            description: string;
+            num_installments: number;
+            is_bnpl: boolean;
+        }>,
+    ): Promise<void> {
+        try {
+            const { error } = await supabase.rpc(
+                "bulk_create_purchases_with_transactions",
+                {
+                    p_purchases: purchases,
+                },
+            );
+
+            if (error) throw error;
+        } catch (error) {
+            console.error("Error bulk creating purchases with transactions:", error);
+            throw error;
+        }
+    }
 }

--- a/src/lib/services/dataService.ts
+++ b/src/lib/services/dataService.ts
@@ -1,4 +1,5 @@
 import { supabase, Purchase, CreditCard, Person } from "@/lib/supabase";
+import { addMonthsPreservingMonthEnd } from "@/lib/utils";
 
 export class DataService {
     /**
@@ -132,10 +133,11 @@ export class DataService {
                 purchaseData.total_amount / purchaseData.num_installments;
 
             for (let i = 0; i < purchaseData.num_installments; i++) {
-                // Calculate the transaction date based on billing start date
-                const startDate = new Date(purchaseData.billing_start_date);
-                const transactionDate = new Date(startDate);
-                transactionDate.setMonth(startDate.getMonth() + i);
+                // Calculate the transaction date using Postgres-equivalent month addition
+                const transactionDateStr = addMonthsPreservingMonthEnd(
+                    purchaseData.billing_start_date,
+                    i,
+                );
 
                 // Create a transaction for this installment
                 const { error: transactionError } = await supabase
@@ -143,7 +145,7 @@ export class DataService {
                     .insert({
                         credit_card_id: purchaseData.credit_card_id,
                         person_id: purchaseData.person_id,
-                        date: transactionDate.toISOString().split("T")[0],
+                        date: transactionDateStr,
                         amount: installmentAmount,
                         description:
                             purchaseData.num_installments > 1
@@ -173,9 +175,9 @@ export class DataService {
             num_installments: number;
             is_bnpl: boolean;
         }>,
-    ): Promise<void> {
+    ): Promise<string[]> {
         try {
-            const { error } = await supabase.rpc(
+            const { data, error } = await supabase.rpc(
                 "bulk_create_purchases_with_transactions",
                 {
                     p_purchases: purchases,
@@ -183,6 +185,7 @@ export class DataService {
             );
 
             if (error) throw error;
+            return data || [];
         } catch (error) {
             console.error("Error bulk creating purchases with transactions:", error);
             throw error;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -56,3 +56,31 @@ export async function handleTransactionPaidChange<
     }
     setUpdatingId(null);
 }
+
+/**
+ * Adds months to a date string (YYYY-MM-DD) preserving month-end clamping behavior (Postgres semantics).
+ * E.g., Jan 31 + 1 month = Feb 28 (or 29 in leap year), not March 3rd.
+ * @param dateStr Date string in YYYY-MM-DD format
+ * @param monthsToAdd Number of months to add
+ * @returns Date string in YYYY-MM-DD format
+ */
+export function addMonthsPreservingMonthEnd(dateStr: string, monthsToAdd: number): string {
+    const [yearStr, monthStr, dayStr] = dateStr.split("-");
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10) - 1; // 0-indexed month
+    const day = parseInt(dayStr, 10);
+
+    let targetMonth = month + monthsToAdd;
+    const targetYear = year + Math.floor(targetMonth / 12);
+    targetMonth = ((targetMonth % 12) + 12) % 12; // handle negative offset if any
+
+    const isLeapYear = (y: number) => (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
+    const daysInMonths = [31, isLeapYear(targetYear) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+    const targetDay = Math.min(day, daysInMonths[targetMonth]);
+
+    const formattedMonth = String(targetMonth + 1).padStart(2, "0");
+    const formattedDay = String(targetDay).padStart(2, "0");
+
+    return `${targetYear}-${formattedMonth}-${formattedDay}`;
+}

--- a/supabase/migrations/20260607_bulk_create_purchases.sql
+++ b/supabase/migrations/20260607_bulk_create_purchases.sql
@@ -1,0 +1,77 @@
+-- Migration: Create bulk purchase transactional RPC function
+-- Date: 2026-06-07
+-- Purpose: Bulk insert purchases and their associated installment transactions atomically inside a single database transaction
+
+CREATE OR REPLACE FUNCTION bulk_create_purchases_with_transactions(
+    p_purchases JSONB
+) RETURNS VOID AS $$
+DECLARE
+    v_purchase_item JSONB;
+    v_purchase_id UUID;
+    v_installment_amount NUMERIC;
+    v_billing_start_date DATE;
+    v_num_installments INTEGER;
+    v_description TEXT;
+    v_credit_card_id UUID;
+    v_person_id UUID;
+    v_purchase_date DATE;
+    v_is_bnpl BOOLEAN;
+    i INTEGER;
+BEGIN
+    FOR v_purchase_item IN SELECT * FROM jsonb_array_elements(p_purchases) LOOP
+        -- Extract values
+        v_credit_card_id := (v_purchase_item->>'credit_card_id')::UUID;
+        v_person_id := (v_purchase_item->>'person_id')::UUID;
+        v_purchase_date := (v_purchase_item->>'purchase_date')::DATE;
+        v_billing_start_date := (v_purchase_item->>'billing_start_date')::DATE;
+        v_description := v_purchase_item->>'description';
+        v_is_bnpl := COALESCE((v_purchase_item->>'is_bnpl')::BOOLEAN, false);
+        v_num_installments := COALESCE((v_purchase_item->>'num_installments')::INTEGER, 1);
+        v_installment_amount := (v_purchase_item->>'total_amount')::NUMERIC / v_num_installments;
+
+        -- Insert purchase
+        INSERT INTO purchases (
+            credit_card_id,
+            person_id,
+            purchase_date,
+            billing_start_date,
+            total_amount,
+            description,
+            num_installments,
+            is_bnpl
+        ) VALUES (
+            v_credit_card_id,
+            v_person_id,
+            v_purchase_date,
+            v_billing_start_date,
+            (v_purchase_item->>'total_amount')::NUMERIC,
+            v_description,
+            v_num_installments,
+            v_is_bnpl
+        ) RETURNING id INTO v_purchase_id;
+
+        -- Insert transactions
+        FOR i IN 0..(v_num_installments - 1) LOOP
+            INSERT INTO transactions (
+                credit_card_id,
+                person_id,
+                purchase_id,
+                date,
+                amount,
+                description
+            ) VALUES (
+                v_credit_card_id,
+                v_person_id,
+                v_purchase_id,
+                (v_billing_start_date + (i * INTERVAL '1 month'))::DATE,
+                v_installment_amount,
+                CASE
+                    WHEN v_num_installments > 1
+                        THEN format('%s (Installment %s/%s)', v_description, i + 1, v_num_installments)
+                    ELSE v_description
+                END
+            );
+        END LOOP;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;

--- a/supabase/migrations/20260607_bulk_create_purchases.sql
+++ b/supabase/migrations/20260607_bulk_create_purchases.sql
@@ -28,6 +28,10 @@ BEGIN
         v_description := v_purchase_item->>'description';
         v_is_bnpl := COALESCE((v_purchase_item->>'is_bnpl')::BOOLEAN, false);
         v_num_installments := COALESCE((v_purchase_item->>'num_installments')::INTEGER, 1);
+        IF v_num_installments < 1 THEN
+            RAISE EXCEPTION 'num_installments must be >= 1, got %', v_num_installments
+                USING ERRCODE = '22023';
+        END IF;
         v_installment_amount := (v_purchase_item->>'total_amount')::NUMERIC / v_num_installments;
 
         -- Insert purchase
@@ -78,4 +82,4 @@ BEGIN
     END LOOP;
     RETURN v_created_ids;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+$$ LANGUAGE plpgsql SECURITY INVOKER SET search_path = public;

--- a/supabase/migrations/20260607_bulk_create_purchases.sql
+++ b/supabase/migrations/20260607_bulk_create_purchases.sql
@@ -4,7 +4,7 @@
 
 CREATE OR REPLACE FUNCTION bulk_create_purchases_with_transactions(
     p_purchases JSONB
-) RETURNS VOID AS $$
+) RETURNS UUID[] AS $$
 DECLARE
     v_purchase_item JSONB;
     v_purchase_id UUID;
@@ -16,6 +16,7 @@ DECLARE
     v_person_id UUID;
     v_purchase_date DATE;
     v_is_bnpl BOOLEAN;
+    v_created_ids UUID[] := ARRAY[]::UUID[];
     i INTEGER;
 BEGIN
     FOR v_purchase_item IN SELECT * FROM jsonb_array_elements(p_purchases) LOOP
@@ -50,6 +51,8 @@ BEGIN
             v_is_bnpl
         ) RETURNING id INTO v_purchase_id;
 
+        v_created_ids := v_created_ids || v_purchase_id;
+
         -- Insert transactions
         FOR i IN 0..(v_num_installments - 1) LOOP
             INSERT INTO transactions (
@@ -73,5 +76,6 @@ BEGIN
             );
         END LOOP;
     END LOOP;
+    RETURN v_created_ids;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk purchase workflow: multi-row spreadsheet-style form with batch defaults, row add/duplicate/remove, validation, and loading/error handling, plus a “Back to Purchases” link.
  * Added a “Bulk Add Purchases” action on the Purchases page; successful submissions return to Purchases.
* **Bug Fixes**
  * Installment transaction dates now preserve month-end correctly across month boundaries.
* **Tests**
  * Added UI and service tests for row behavior, cascading defaults, validation, submit/cancel, and RPC error handling.
* **Chores**
  * Added a database migration/RPC for atomic bulk purchase + transaction creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->