### PR TITLE
fix: person transactions loading + purchase flow guards & a11y

### DIFF
--- a/src/app/purchases/page.tsx
+++ b/src/app/purchases/page.tsx
@@ -111,6 +111,9 @@ export default function PurchasesPage() {
         return matchesPerson && matchesCard && matchesDescription;
     });
 
+    const hasPurchasePrerequisites =
+        creditCards.length > 0 && persons.length > 0;
+
     if (isLoading) {
         return <LoadingSpinner />;
     }
@@ -131,9 +134,28 @@ export default function PurchasesPage() {
     return (
         <div className="container space-y-5 mx-auto">
             <h1 className="heading-page">Purchases</h1>
-            <button onClick={openAddModal} className="btn btn-primary">
-                Add Purchase
-            </button>
+            <div className="space-y-2">
+                <button
+                    onClick={openAddModal}
+                    className="btn btn-primary"
+                    disabled={!hasPurchasePrerequisites}
+                    title={
+                        hasPurchasePrerequisites
+                            ? undefined
+                            : "Add at least one credit card and one person before creating a purchase"
+                    }
+                >
+                    Add Purchase
+                </button>
+                {!hasPurchasePrerequisites && (
+                    <div className="alert alert-info">
+                        <span>
+                            Add at least one person and one credit card before
+                            creating a purchase.
+                        </span>
+                    </div>
+                )}
+            </div>
 
             <TransactionFilters
                 config={{
@@ -241,6 +263,7 @@ export default function PurchasesPage() {
                 <PurchaseForm
                     creditCards={creditCards}
                     persons={persons}
+                    hasPrerequisites={hasPurchasePrerequisites}
                     onSubmit={handleFormSubmit}
                     onCancel={closeModal}
                 />

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -148,6 +148,16 @@ export default function TransactionsPage() {
         );
     }
 
+    function getPaidToggleLabel(transaction: Transaction) {
+        const transactionTarget =
+            transaction.description.trim() ||
+            `transaction on ${formatDate(transaction.date)}`;
+
+        return transaction.paid
+            ? `Mark ${transactionTarget} as unpaid`
+            : `Mark ${transactionTarget} as paid`;
+    }
+
     const filteredTransactions = transactions.filter((tr) => {
         const matchesPerson = filterPerson
             ? tr.expand?.person?.id === filterPerson
@@ -288,6 +298,7 @@ export default function TransactionsPage() {
                                     )
                                 }
                                 disabled={updatingId === transaction.id}
+                                aria-label={getPaidToggleLabel(transaction)}
                             />
                         ),
                     },

--- a/src/app/transactions/person/[slug]/page.tsx
+++ b/src/app/transactions/person/[slug]/page.tsx
@@ -157,6 +157,16 @@ export default function PersonTransactionsPage() {
         );
     }
 
+    function getPaidToggleLabel(transaction: Transaction) {
+        const transactionTarget =
+            transaction.description.trim() ||
+            `transaction on ${formatDate(transaction.date)}`;
+
+        return transaction.paid
+            ? `Mark ${transactionTarget} as unpaid`
+            : `Mark ${transactionTarget} as paid`;
+    }
+
     const filteredTransactions = useMemo(() => {
         return transactions.filter((tr) => {
             const matchesCard = filters.card
@@ -249,6 +259,7 @@ export default function PersonTransactionsPage() {
                                     )
                                 }
                                 disabled={updatingId === transaction.id}
+                                aria-label={getPaidToggleLabel(transaction)}
                             />
                         ),
                     },

--- a/src/app/transactions/person/[slug]/page.tsx
+++ b/src/app/transactions/person/[slug]/page.tsx
@@ -12,6 +12,7 @@ import DataTable from "@/components/DataTable";
 import TransactionFilters, {
     TransactionFiltersState,
 } from "@/components/transactions/TransactionFilters";
+import { LoadingSpinner } from "@/components/base";
 
 export default function PersonTransactionsPage() {
     const { slug: personSlug } = useParams() as { slug: string };
@@ -20,6 +21,7 @@ export default function PersonTransactionsPage() {
     const [creditCards, setCreditCards] = useState<CreditCard[]>([]);
     const [person, setPerson] = useState<Person | null>(null);
     const [updatingId, setUpdatingId] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [filters, setFilters] = useState<TransactionFiltersState>({
         person: "",
@@ -112,23 +114,37 @@ export default function PersonTransactionsPage() {
         }
     }, []);
 
+    const loadPageData = useCallback(async () => {
+        if (!personSlug) return;
+
+        try {
+            setIsLoading(true);
+            setError(null);
+
+            const personData = await loadPerson();
+
+            if (!personData) {
+                setTransactions([]);
+                setCreditCards([]);
+                return;
+            }
+
+            await Promise.all([
+                loadTransactions(personData.id),
+                loadCreditCards(),
+            ]);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [personSlug, loadCreditCards, loadPerson, loadTransactions]);
+
     useEffect(() => {
         if (!personSlug) return;
         if (hasFetchedRef.current === personSlug) return;
         hasFetchedRef.current = personSlug;
 
-        const fetchData = async () => {
-            const personData = await loadPerson();
-            if (personData) {
-                await Promise.all([
-                    loadTransactions(personData.id),
-                    loadCreditCards(),
-                ]);
-            }
-        };
-
-        fetchData();
-    }, [personSlug, loadPerson, loadTransactions, loadCreditCards]);
+        loadPageData();
+    }, [personSlug, loadPageData]);
 
     const isPayment = (amount: number) => amount < 0;
 
@@ -173,13 +189,17 @@ export default function PersonTransactionsPage() {
         });
     }, [transactions, filters]);
 
+    if (isLoading) {
+        return <LoadingSpinner text="Loading person transactions..." />;
+    }
+
     return (
         <div className="container space-y-5 mx-auto">
             {error && (
                 <div className="alert alert-error mb-4">
                     <span>{error}</span>
                     <button
-                        onClick={() => person && loadTransactions(person.id)}
+                        onClick={loadPageData}
                         className="btn btn-sm btn-primary"
                     >
                         Retry

--- a/src/components/PurchaseForm.tsx
+++ b/src/components/PurchaseForm.tsx
@@ -23,6 +23,7 @@ interface PurchaseFormData {
 interface PurchaseFormProps {
     creditCards: CreditCard[];
     persons: Person[];
+    hasPrerequisites?: boolean;
     onSubmit: (formData: {
         credit_card_id: string;
         person_id: string;
@@ -39,6 +40,7 @@ interface PurchaseFormProps {
 export default function PurchaseForm({
     creditCards,
     persons,
+    hasPrerequisites = true,
     onSubmit,
     onCancel,
 }: PurchaseFormProps) {
@@ -109,7 +111,7 @@ export default function PurchaseForm({
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
 
-        if (isSubmitting) return;
+        if (isSubmitting || !canCreatePurchase) return;
 
         setIsSubmitting(true);
         try {
@@ -148,8 +150,21 @@ export default function PurchaseForm({
         value: person.id,
         label: person.name,
     }));
+
+    const canCreatePurchase =
+        hasPrerequisites && creditCards.length > 0 && persons.length > 0;
+
     return (
         <form onSubmit={handleSubmit} data-component="PurchaseForm">
+            {!canCreatePurchase && (
+                <div className="alert alert-warning mb-4">
+                    <span>
+                        Add at least one credit card and one person before
+                        creating a purchase.
+                    </span>
+                </div>
+            )}
+
             <div className="form-control mb-4">
                 <div className="label">
                     <span className="label-text">Credit Card</span>
@@ -162,7 +177,7 @@ export default function PurchaseForm({
                     }
                     options={creditCardOptions}
                     required
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !canCreatePurchase}
                 />
             </div>
 
@@ -176,7 +191,7 @@ export default function PurchaseForm({
                     onChange={(value) => handleSelectChange("person_id", value)}
                     options={personOptions}
                     required
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !canCreatePurchase}
                 />
             </div>
 
@@ -189,7 +204,7 @@ export default function PurchaseForm({
                     value={formData.purchase_date}
                     onChange={handleInputChange}
                     required
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !canCreatePurchase}
                 />
             </div>
 
@@ -203,7 +218,7 @@ export default function PurchaseForm({
                     step="0.01"
                     min="0"
                     required
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !canCreatePurchase}
                 />
             </div>
 
@@ -214,7 +229,7 @@ export default function PurchaseForm({
                     value={formData.description}
                     onChange={handleInputChange}
                     required
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !canCreatePurchase}
                 />
             </div>
 
@@ -227,7 +242,7 @@ export default function PurchaseForm({
                     onChange={handleInputChange}
                     min="1"
                     required
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !canCreatePurchase}
                 />
             </div>
 
@@ -238,7 +253,7 @@ export default function PurchaseForm({
                     checked={formData.is_bnpl}
                     onChange={handleInputChange}
                     labelPosition="right"
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !canCreatePurchase}
                 />
             </div>
 
@@ -251,7 +266,7 @@ export default function PurchaseForm({
                     value={formData.billing_start_date}
                     onChange={handleInputChange}
                     required
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !canCreatePurchase}
                 />
             </div>
 
@@ -264,7 +279,11 @@ export default function PurchaseForm({
                 >
                     Cancel
                 </Button>
-                <Button type="submit" color="primary" disabled={isSubmitting}>
+                <Button
+                    type="submit"
+                    color="primary"
+                    disabled={isSubmitting || !canCreatePurchase}
+                >
                     {isSubmitting ? "Saving..." : "Save"}
                 </Button>
             </div>


### PR DESCRIPTION
## Summary

Two focused fixes on top of `main` (last common ancestor: `bd6cf03`).

- **`3925033` — guard blocked purchase flow and person loading state**
  Prevents interacting with the blocked purchase flow and adds a proper loading state for person data, avoiding flashes of unpopulated UI.
- **`64a3a2f` — label transaction paid toggles (a11y)**
  Adds accessible labels to the transaction "paid" toggles so screen-reader users understand each control's purpose.

## Notes

- No tests on this branch — the vitest/playwright setup was introduced later in main (PR #12) and is not in this branch's history. Lint passes clean (`next lint`, 0 warnings/errors).
- Merge simulates **clean** (no conflicts) against `origin/main` — these commits touch files distinct from those changed by PR #12.
- A separate in-progress design-system refactor (theme rename, icons rewrite, component restyling) was stashed locally and is **not** part of this PR.

## Test Plan

- [ ] Open a person's transactions page (`/transactions/person/[slug]`) and confirm the loading state shows before data renders.
- [ ] Attempt the blocked purchase flow and confirm it is guarded (no broken interaction).
- [ ] With a screen reader / accessibility inspector, verify each transaction paid toggle has a discernible label.
- [ ] `npm run lint` passes (verified locally: 0 warnings/errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Purchase creation now requires credit cards and persons to be loaded. Users see an informational alert and disabled button when prerequisites are unavailable.
  * Improved error handling in person transactions with more reliable retry functionality.

* **Accessibility**
  * Transaction paid checkboxes now include descriptive labels for better screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->